### PR TITLE
Add getRawDays

### DIFF
--- a/lib/Table.ts
+++ b/lib/Table.ts
@@ -47,7 +47,7 @@ export default class Table {
     rows.forEach((row, index): void => {
       const lessons = this.$(row).find('.l').toArray();
       lessons.forEach((lesson): void => {
-        days[index] || days.push([]);
+        if (!days[index]) days.push([]);
         if (this.$(lesson).children().length === 0) {
           days[index].push([]);
         } else {
@@ -87,7 +87,7 @@ export default class Table {
     return days;
   }
 
-  private parseLessons(data: any[]): Record<string, string>[] {
+  private parseLessons(data: CheerioElement[]): Record<string, string>[] {
     let groups: Record<string, string>[] = [{}];
     let groupNumber = 0;
     let commaSeperated = false;

--- a/lib/Table.ts
+++ b/lib/Table.ts
@@ -28,6 +28,31 @@ export default class Table {
     return hours;
   }
 
+  /*
+  * Return table in original form (without transposing) for easier displaying.
+  */
+  public getRawDays(): Record<string, string>[][][] {
+    const rows = this.$('.tabela tr:not(:first-of-type)').toArray();
+
+    const days: Record<string, string>[][][] = [];
+
+    rows.forEach((row, index): void => {
+      const lessons = this.$(row).find('.l').toArray();
+      lessons.forEach((lesson): void => {
+        days[index] || days.push([]);
+        if (this.$(lesson).children().length === 0) {
+          days[index].push([]);
+        } else {
+          const groups = this.parseLessons(this.$(lesson).contents().toArray());
+          days[index].push(groups);
+        }
+      });
+    });
+
+    return days;
+  }
+
+
   public getDays(): Record<string, string>[][][] {
     const rows = this.$('.tabela tr:not(:first-of-type)').toArray();
 
@@ -45,103 +70,110 @@ export default class Table {
         if (this.$(lesson).children().length === 0) {
           days[index].push([]);
         } else {
-          let groups: Record<string, string>[] = [{}];
-          let groupNumber = 0;
-          let commaSeperated = false;
-          this.$(lesson).contents().toArray().forEach((element): void => {
-            if (element.tagName === 'br') {
-              groupNumber += 1;
-              groups[groupNumber] = {};
-            } else if (/,/.test(this.$(element).text())) {
-              const groupNameMatch = this.$(element).text().match(/-\d{1,}\/\d{1,}/);
-
-              if (groupNameMatch) {
-                groups[groupNumber].groupName = groupNameMatch[0].substr(1);
-              }
-
-              groupNumber += 1;
-              groups[groupNumber] = {};
-              commaSeperated = true;
-
-              if (groups[groupNumber - 1].teacher) {
-                groups[groupNumber].teacher = groups[groupNumber - 1].teacher;
-              }
-
-              if (groups[groupNumber - 1].subject) {
-                groups[groupNumber].subject = groups[groupNumber - 1].subject;
-              }
-            } else {
-              const groupNameMatch = this.$(element).text().match(/-\d{1,}\/\d{1,}/);
-
-              if (groupNameMatch) {
-                groups[groupNumber].groupName = groupNameMatch[0].substr(1);
-              }
-
-              if (this.$(element).hasClass('p')) {
-                if (!groups[groupNumber].subject) {
-                  groups[groupNumber].subject = this.$(element).text().replace(/-\d{1,}\/\d{1,}/, '');
-                } else {
-                  groups[groupNumber].subject += ' ';
-                  groups[groupNumber].subject += this.$(element).text().replace(/-\d{1,}\/\d{1,}/, '');
-                }
-              }
-
-              if (this.$(element).find('.p').length !== 0) {
-                if (!groups[groupNumber].subject) {
-                  groups[groupNumber].subject = this.$(element).find('.p').text().replace(/-\d{1,}\/\d{1,}/, '');
-                } else {
-                  groups[groupNumber].subject += ' ';
-                  groups[groupNumber].subject += this.$(element).find('.p').text().replace(/-\d{1,}\/\d{1,}/, '');
-                }
-              }
-
-              if (this.$(element).hasClass('n')) {
-                groups[groupNumber].teacher = this.$(element).text();
-              }
-
-              if (this.$(element).find('.n').length !== 0) {
-                groups[groupNumber].teacher = this.$(element).find('.n').text();
-              }
-
-              if (this.$(element).hasClass('o')) {
-                groups[groupNumber].className = this.$(element).text();
-              }
-
-              if (this.$(element).find('.o').length !== 0) {
-                groups[groupNumber].className = this.$(element).find('.o').text();
-              }
-
-              if (this.$(element).hasClass('s')) {
-                groups[groupNumber].room = this.$(element).text();
-              }
-
-              if (this.$(element).find('.s').length !== 0) {
-                groups[groupNumber].room = this.$(element).find('.s').text();
-              }
-
-              if (commaSeperated) {
-                groups.slice(0, groups.length - 1).forEach((group, groupIndex): void => {
-                  if (!groups[groupIndex].teacher && groups[groupNumber].teacher) {
-                    groups[groupIndex].teacher = groups[groupNumber].teacher;
-                  }
-
-                  if (!groups[groupIndex].subject && groups[groupNumber].subject) {
-                    groups[groupIndex].subject = groups[groupNumber].subject;
-                  }
-                });
-              }
-            }
-          });
-
-          groups = groups.filter(
-            (group): boolean => (Object.getOwnPropertyNames(group).length !== 0),
-          );
-
+          const groups = this.parseLessons(this.$(lesson).contents().toArray());
           days[index].push(groups);
         }
       });
     });
 
     return days;
+  }
+
+  private parseLessons(data: any[]): Record<string, string>[] {
+    let groups: Record<string, string>[] = [{}];
+    let groupNumber = 0;
+    let commaSeperated = false;
+
+
+    data.forEach((element): void => {
+      if (element.tagName === 'br') {
+        groupNumber += 1;
+        groups[groupNumber] = {};
+      } else if (/,/.test(this.$(element).text())) {
+        const groupNameMatch = this.$(element).text().match(/-\d{1,}\/\d{1,}/);
+
+        if (groupNameMatch) {
+          groups[groupNumber].groupName = groupNameMatch[0].substr(1);
+        }
+
+        groupNumber += 1;
+        groups[groupNumber] = {};
+        commaSeperated = true;
+
+        if (groups[groupNumber - 1].teacher) {
+          groups[groupNumber].teacher = groups[groupNumber - 1].teacher;
+        }
+
+        if (groups[groupNumber - 1].subject) {
+          groups[groupNumber].subject = groups[groupNumber - 1].subject;
+        }
+      } else {
+        const groupNameMatch = this.$(element).text().match(/-\d{1,}\/\d{1,}/);
+
+        if (groupNameMatch) {
+          groups[groupNumber].groupName = groupNameMatch[0].substr(1);
+        }
+
+        if (this.$(element).hasClass('p')) {
+          if (!groups[groupNumber].subject) {
+            groups[groupNumber].subject = this.$(element).text().replace(/-\d{1,}\/\d{1,}/, '');
+          } else {
+            groups[groupNumber].subject += ' ';
+            groups[groupNumber].subject += this.$(element).text().replace(/-\d{1,}\/\d{1,}/, '');
+          }
+        }
+
+        if (this.$(element).find('.p').length !== 0) {
+          if (!groups[groupNumber].subject) {
+            groups[groupNumber].subject = this.$(element).find('.p').text().replace(/-\d{1,}\/\d{1,}/, '');
+          } else {
+            groups[groupNumber].subject += ' ';
+            groups[groupNumber].subject += this.$(element).find('.p').text().replace(/-\d{1,}\/\d{1,}/, '');
+          }
+        }
+
+        if (this.$(element).hasClass('n')) {
+          groups[groupNumber].teacher = this.$(element).text();
+        }
+
+        if (this.$(element).find('.n').length !== 0) {
+          groups[groupNumber].teacher = this.$(element).find('.n').text();
+        }
+
+        if (this.$(element).hasClass('o')) {
+          groups[groupNumber].className = this.$(element).text();
+        }
+
+        if (this.$(element).find('.o').length !== 0) {
+          groups[groupNumber].className = this.$(element).find('.o').text();
+        }
+
+        if (this.$(element).hasClass('s')) {
+          groups[groupNumber].room = this.$(element).text();
+        }
+
+        if (this.$(element).find('.s').length !== 0) {
+          groups[groupNumber].room = this.$(element).find('.s').text();
+        }
+
+        if (commaSeperated) {
+          groups.slice(0, groups.length - 1).forEach((group, groupIndex): void => {
+            if (!groups[groupIndex].teacher && groups[groupNumber].teacher) {
+              groups[groupIndex].teacher = groups[groupNumber].teacher;
+            }
+
+            if (!groups[groupIndex].subject && groups[groupNumber].subject) {
+              groups[groupIndex].subject = groups[groupNumber].subject;
+            }
+          });
+        }
+      }
+    });
+
+    groups = groups.filter(
+      (group): boolean => (Object.getOwnPropertyNames(group).length !== 0),
+    );
+
+    return groups;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,32 @@
 {
-  "name": "timetable-parser",
+  "name": "@wulkanowy/timetable-parser",
   "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "^7.10.4"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
     "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "dev": true,
       "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
     },
@@ -103,24 +109,24 @@
       }
     },
     "acorn": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -305,9 +311,9 @@
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
     "cliui": {
@@ -732,12 +738,20 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
@@ -777,9 +791,9 @@
       }
     },
     "external-editor": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
       "requires": {
         "chardet": "^0.7.0",
@@ -788,15 +802,15 @@
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
     "fast-levenshtein": {
@@ -853,9 +867,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
     "fs.realpath": {
@@ -898,9 +912,9 @@
       }
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -991,9 +1005,9 @@
       "dev": true
     },
     "import-fresh": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
-      "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -1022,9 +1036,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
-      "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.2.0",
@@ -1033,7 +1047,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^2.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.12",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.4.0",
@@ -1093,12 +1107,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
     "is-regex": {
@@ -1587,17 +1595,17 @@
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       }
     },
     "os-locale": {
@@ -1855,18 +1863,15 @@
       }
     },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
     },
     "rxjs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -2036,13 +2041,13 @@
       }
     },
     "table": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
-      "integrity": "sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
-        "ajv": "^6.9.1",
-        "lodash": "^4.17.11",
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
       },
@@ -2154,9 +2159,9 @@
       "dev": true
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -2201,10 +2206,10 @@
         "string-width": "^1.0.2 || 2"
       }
     },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wulkanowy/timetable-parser",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "VULCAN Optivum Timetable parser for JavaScript",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/test/test.ts
+++ b/test/test.ts
@@ -228,6 +228,12 @@ describe('Table test', (): void => {
       ]);
     });
 
+    it('getRawDays does not throw an error', (): void => {
+      const rawTable = table.getRawDays();
+      console.log(rawTable);
+    })
+
+
     it('Table hours return check', (): void => {
       const tableHours = table.getHours();
       expect(tableHours).to.eql({

--- a/test/test.ts
+++ b/test/test.ts
@@ -234,9 +234,8 @@ describe('Table test', (): void => {
     });
 
     it('getRawDays does not throw an error', (): void => {
-      const rawTable = table.getRawDays();
-      console.log(rawTable);
-    })
+      table.getRawDays();
+    });
 
 
     it('Table hours return check', (): void => {


### PR DESCRIPTION
Hi,
I added `getRawDays` function that returns Table in its original form - without transposing. It'll come handy with printing timetable in terminal or when building an HTML table, as you work row by row there. Of course, you could rotate it by yourself but Table in `getDays` already transposes it - so that means that we do unneeded calculations :-1:.